### PR TITLE
Correctly parse DWARF EH tables on architectures with strict alignment

### DIFF
--- a/src/dwarf_eh.h
+++ b/src/dwarf_eh.h
@@ -218,15 +218,17 @@ static int64_t read_sleb128(dw_eh_ptr_t *data)
 static uint64_t read_value(char encoding, dw_eh_ptr_t *data)
 {
 	enum dwarf_data_encoding type = get_encoding(encoding);
-	uint64_t v;
 	switch (type)
 	{
 		// Read fixed-length types
 #define READ(dwarf, type) \
 		case dwarf:\
-			v = static_cast<uint64_t>(*reinterpret_cast<type*>(*data));\
-			*data += sizeof(type);\
-			break;
+		{\
+			type t;\
+			memcpy(&t, *data, sizeof t);\
+			*data += sizeof t;\
+			return static_cast<uint64_t>(t);\
+		}
 		READ(DW_EH_PE_udata2, uint16_t)
 		READ(DW_EH_PE_udata4, uint32_t)
 		READ(DW_EH_PE_udata8, uint64_t)
@@ -237,15 +239,11 @@ static uint64_t read_value(char encoding, dw_eh_ptr_t *data)
 #undef READ
 		// Read variable-length types
 		case DW_EH_PE_sleb128:
-			v = read_sleb128(data);
-			break;
+			return read_sleb128(data);
 		case DW_EH_PE_uleb128:
-			v = read_uleb128(data);
-			break;
+			return read_uleb128(data);
 		default: abort();
 	}
-
-	return v;
 }
 
 /**


### PR DESCRIPTION
In the thread starting [here on the freebsd-arm mailing list](https://lists.freebsd.org/pipermail/freebsd-arm/2015-January/009998.html), Daisuke Aoyama describes how libcxxrt does not properly handle parsing an exception table on an RPi (e.g. arm). This is because parts of `dwarf_eh.h` read 16 bit, 32 bit and 64 bit values directly from possibly unaligned addresses.

He posted a workaround patch [here](https://lists.freebsd.org/pipermail/freebsd-arm/2015-January/010014.html), but it is incomplete, as it does not handle the 16 and 64 bit cases, nor does it work for other architectures with strict alignment.

I submitted an improved patch for review on FreeBSD's Phabricator, and after a short discussion we eventually committed the version in this pull request.  It replaces the direct dereferencing with mempcy(), which works on almost all platforms, and simplifies the read_value() function a little by eliminating the unnecessary `v` variable.

Obtained from: https://reviews.freebsd.org/rS279307