### PR TITLE
Add std::uncaught_exceptions().

### DIFF
--- a/src/exception.cc
+++ b/src/exception.cc
@@ -1472,6 +1472,15 @@ namespace std
 		return info->globals.uncaughtExceptions != 0;
 	}
 	/**
+	 * Returns the number of exceptions currently being thrown that have not
+	 * been caught.  This can occur inside a nested catch statement.
+	 */
+	int uncaught_exceptions() throw()
+	{
+		__cxa_thread_info *info = thread_info();
+		return info->globals.uncaughtExceptions;
+	}
+	/**
 	 * Returns the current unexpected handler.
 	 */
 	unexpected_handler get_unexpected() throw()


### PR DESCRIPTION
For C++1y, this adds `std::uncaught_exceptions()`, which returns the number of exceptions currently being thrown that have not been caught.  Implemented almost exactly like `std::uncaught_exception()`.

If you prefer implementing the latter in terms of the former, please let me know.
