### PR TITLE
Foreign exceptions interoperability

### DIFF
--- a/src/exception.cc
+++ b/src/exception.cc
@@ -344,7 +344,8 @@ static void thread_cleanup(void* thread_info)
 		if (info->foreign_exception_state != __cxa_thread_info::none)
 		{
 			_Unwind_Exception *e = reinterpret_cast<_Unwind_Exception*>(info->globals.caughtExceptions);
-			e->exception_cleanup(_URC_FOREIGN_EXCEPTION_CAUGHT, e);
+			if (e->exception_cleanup)
+				e->exception_cleanup(_URC_FOREIGN_EXCEPTION_CAUGHT, e);
 		}
 		else
 		{
@@ -1284,12 +1285,13 @@ extern "C" void __cxa_end_catch()
 	
 	if (ti->foreign_exception_state != __cxa_thread_info::none)
 	{
-		globals->caughtExceptions = 0;
 		if (ti->foreign_exception_state != __cxa_thread_info::rethrown)
 		{
 			_Unwind_Exception *e = reinterpret_cast<_Unwind_Exception*>(ti->globals.caughtExceptions);
-			e->exception_cleanup(_URC_FOREIGN_EXCEPTION_CAUGHT, e);
+			if (e->exception_cleanup)
+				e->exception_cleanup(_URC_FOREIGN_EXCEPTION_CAUGHT, e);
 		}
+		globals->caughtExceptions = 0;
 		ti->foreign_exception_state = __cxa_thread_info::none;
 		return;
 	}

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -304,13 +304,17 @@ static pthread_key_t eh_key;
 static void exception_cleanup(_Unwind_Reason_Code reason, 
                               struct _Unwind_Exception *ex)
 {
-	__cxa_free_exception(static_cast<void*>(ex));
+	// Exception layout:
+	// [__cxa_exception [_Unwind_Exception]] [exception object]
+	//
+	// __cxa_free_exception expects a pointer to the exception object
+	__cxa_free_exception(static_cast<void*>(ex + 1));
 }
 static void dependent_exception_cleanup(_Unwind_Reason_Code reason, 
                               struct _Unwind_Exception *ex)
 {
 
-	__cxa_free_dependent_exception(static_cast<void*>(ex));
+	__cxa_free_dependent_exception(static_cast<void*>(ex + 1));
 }
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,11 @@ add_executable(cxxrt-test-shared ${CXXTEST_SOURCES})
 set_property(TARGET cxxrt-test-shared PROPERTY LINK_FLAGS -nodefaultlibs)
 target_link_libraries(cxxrt-test-shared cxxrt-shared pthread dl c)
 
+include_directories(${CMAKE_SOURCE_DIR}/src)
+add_executable(cxxrt-test-foreign-exceptions test_foreign_exceptions.cc)
+set_property(TARGET cxxrt-test-foreign-exceptions PROPERTY LINK_FLAGS "-nodefaultlibs -Wl,--wrap,_Unwind_RaiseException")
+target_link_libraries(cxxrt-test-foreign-exceptions cxxrt-static gcc_s pthread dl c)
+
 add_test(cxxrt-test-static-test
          ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-static
@@ -34,6 +39,9 @@ add_test(cxxrt-test-shared-test
          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-shared
          ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
          ${CMAKE_CURRENT_BINARY_DIR}/test-shared-output.log)
+
+add_test(cxxrt-test-foreign-exceptions
+         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-foreign-exceptions)
 
 set(valgrind "valgrind -q")
 

--- a/test/test_foreign_exceptions.cc
+++ b/test/test_foreign_exceptions.cc
@@ -1,0 +1,125 @@
+#include <cstdio>
+#include <cstdlib>
+#include "unwind.h"
+
+#define EXCEPTION_CLASS(a,b,c,d,e,f,g,h) \
+	((static_cast<uint64_t>(a) << 56) +\
+	 (static_cast<uint64_t>(b) << 48) +\
+	 (static_cast<uint64_t>(c) << 40) +\
+	 (static_cast<uint64_t>(d) << 32) +\
+	 (static_cast<uint64_t>(e) << 24) +\
+	 (static_cast<uint64_t>(f) << 16) +\
+	 (static_cast<uint64_t>(g) << 8) +\
+	 (static_cast<uint64_t>(h)))
+
+// using ld --wrap=_Unwind_RaiseException hook feature
+extern "C" _Unwind_Reason_Code __real__Unwind_RaiseException (_Unwind_Exception *e);
+extern "C" _Unwind_Reason_Code __wrap__Unwind_RaiseException (_Unwind_Exception *e);
+
+extern "C" _Unwind_Reason_Code __wrap__Unwind_RaiseException (_Unwind_Exception *e)
+{
+	// clobber exception class forcing libcxx own exceptions to be treated
+	// as foreign exception within libcxx itself
+	e->exception_class = EXCEPTION_CLASS('F','O','R','E','I','G','N','\0');
+	__real__Unwind_RaiseException(e);
+}
+
+_Unwind_Exception global_e;
+
+enum test_status {
+	PENDING, PASSED, FAILED
+};
+
+const char test_status_str[][8] = {
+	"PENDING", "PASSED", "FAILED"
+};
+
+test_status test1_status = PENDING;
+test_status test2_status = PENDING;
+test_status test3_status = PENDING;
+
+void test2_exception_cleanup(_Unwind_Reason_Code code, _Unwind_Exception *e)
+{
+	fputs("(2) exception_cleanup called\n", stderr);
+	if (e != &global_e) {
+		fprintf(stderr, "(2) ERROR: unexpected ptr: expecting %p, got %p\n", &global_e, e);
+		test2_status = FAILED;
+	}
+	if (test2_status == PENDING)
+		test2_status = PASSED;
+}
+
+struct test3_exception
+{
+	static int counter;
+	~test3_exception()
+	{
+		counter++;
+		fputs("(3) exception dtor\n", stderr);
+	}
+};
+int test3_exception::counter = 0;
+
+int main()
+{
+	///////////////////////////////////////////////////////////////
+	fputs("(1) foreign exception, exception_cleanup=nullptr\n", stderr);
+	try
+	{
+		global_e.exception_class = 0;
+		global_e.exception_cleanup = 0;
+		__real__Unwind_RaiseException(&global_e);
+	}
+	catch (...)
+	{
+	}
+	test1_status = PASSED;
+	fputs("(1) PASS\n", stderr);
+
+	///////////////////////////////////////////////////////////////
+	fputs("(2) foreign exception, exception_cleanup present\n", stderr);
+	try
+	{
+		global_e.exception_class = 0;
+		global_e.exception_cleanup = test2_exception_cleanup;
+		__real__Unwind_RaiseException(&global_e);
+	}
+	catch (...)
+	{
+	}
+	fprintf(stderr, "(2) %s\n", test_status_str[test2_status]);
+
+	///////////////////////////////////////////////////////////////
+	fputs("(3) C++ exception in foreign environment\n", stderr);
+	int counter_expected;
+	try
+	{
+		// throw was rigged such that the runtime treats C++ exceptions
+		// as foreign ones
+		throw test3_exception();
+	}
+	catch (test3_exception&)
+	{
+		fputs("(3) ERROR: wrong catch\n", stderr);
+		test3_status = FAILED;
+	}
+	catch (...)
+	{
+		fputs("(3) catch(...)\n", stderr);
+		counter_expected = test3_exception::counter + 1;
+		// one more dtor immediately after we leave catch
+	}
+	if (test3_status == PENDING && test3_exception::counter != counter_expected) {
+		fputs("(3) ERROR: exception dtor didn't run\n", stderr);
+		test3_status = FAILED;
+	}
+	if (test3_status == PENDING)
+		test3_status = PASSED;
+	fprintf(stderr, "(3) %s\n", test_status_str[test3_status]);
+
+	///////////////////////////////////////////////////////////////
+	if (test1_status == PASSED && test2_status == PASSED && test3_status == PASSED)
+		return EXIT_SUCCESS;
+	else
+		return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixed 2 issues:

 * libcxxrt C++ exceptions being freed by a different language runtime;
 * libcxxrt itself freeing foreign exceptions.

These issues are known to affect mixed C++/luajit code.