### PR TITLE
Correct exception specifications on new and delete operators

### DIFF
--- a/src/memory.cc
+++ b/src/memory.cc
@@ -71,8 +71,17 @@ namespace std
 }
 
 
+#if __cplusplus < 201103L
+#define NOEXCEPT throw()
+#define BADALLOC throw(std::bad_alloc)
+#else
+#define NOEXCEPT noexcept
+#define BADALLOC
+#endif
+
+
 __attribute__((weak))
-void* operator new(size_t size)
+void* operator new(size_t size) BADALLOC
 {
 	if (0 == size)
 	{
@@ -97,7 +106,7 @@ void* operator new(size_t size)
 }
 
 __attribute__((weak))
-void* operator new(size_t size, const std::nothrow_t &) throw()
+void* operator new(size_t size, const std::nothrow_t &) NOEXCEPT
 {
 	try {
 		return :: operator new(size);
@@ -110,27 +119,21 @@ void* operator new(size_t size, const std::nothrow_t &) throw()
 
 
 __attribute__((weak))
-void operator delete(void * ptr)
-#if __cplusplus < 201000L
-throw()
-#endif
+void operator delete(void * ptr) NOEXCEPT
 {
 	free(ptr);
 }
 
 
 __attribute__((weak))
-void * operator new[](size_t size)
-#if __cplusplus < 201000L
-throw(std::bad_alloc)
-#endif
+void * operator new[](size_t size) BADALLOC
 {
 	return ::operator new(size);
 }
 
 
 __attribute__((weak))
-void * operator new[](size_t size, const std::nothrow_t &) throw()
+void * operator new[](size_t size, const std::nothrow_t &) NOEXCEPT
 {
 	try {
 		return ::operator new[](size);
@@ -143,10 +146,7 @@ void * operator new[](size_t size, const std::nothrow_t &) throw()
 
 
 __attribute__((weak))
-void operator delete[](void * ptr)
-#if __cplusplus < 201000L
-throw()
-#endif
+void operator delete[](void * ptr) NOEXCEPT
 {
 	::operator delete(ptr);
 }


### PR DESCRIPTION
In 67917c0 exception specifications were added to one new operator, and two delete operators, but these specifications are no longer correct for the final C++11 standard, which uses `noexcept` instead of `throw()`.

To fix this, define some macros to add the correct exception specifications, and apply them to:

    void* operator new(size_t)
    void* operator new(size_t, const std::nothrow_t&)
    void operator delete(void*)
    void* operator new[](size_t)
    void* operator new[](size_t, const std::nothrow_t&)
    void operator delete[](void*)

Tested by compiling with clang 3.8.0 and gcc 5.3.0, and using `-std=c++98`, `-std=c++03`, `-std=c++11`, `-std=c++14` and `-std=c++1y`.  No warnings seen anymore.