### PR TITLE
Fixed warning about undeclared asprintf

### DIFF
--- a/src/libelftc_dem_gnu3.c
+++ b/src/libelftc_dem_gnu3.c
@@ -23,15 +23,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#define _GNU_SOURCE
+#include <stdio.h>
 #include <sys/types.h>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 
 /**
  * @file cpp_demangle.c

--- a/src/libelftc_dem_gnu3.c
+++ b/src/libelftc_dem_gnu3.c
@@ -25,16 +25,15 @@
  */
 
 #define _GNU_SOURCE
-#include <stdio.h>
 #include <sys/types.h>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 
 /**
  * @file cpp_demangle.c


### PR DESCRIPTION
Defining _GNU_SOURCE fixes a warning about asprintf being undeclared.