### PR TITLE
Include <stdint.h> in unwind-arm.h, since it uses uint32_t and uint64_t in various declarations

### DIFF
--- a/src/unwind-arm.h
+++ b/src/unwind-arm.h
@@ -20,6 +20,9 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */ 
 
+/* For uint32_t and uint64_t */
+#include <stdint.h>
+
 /**
  * ARM-specific unwind definitions.  These are taken from the ARM EHABI
  * specification.


### PR DESCRIPTION
Otherwise, depending on how unwind-arm.h is included from other source files, the compiler may complain that uint32_t and uint64_t are unknown types.
