### PR TITLE
Fix unwind alignment

### DIFF
--- a/src/unwind-arm.h
+++ b/src/unwind-arm.h
@@ -94,7 +94,7 @@ struct _Unwind_Exception
 	} pr_cache;
 	/** Force alignment of next item to 8-byte boundary */
 	long long int :0;
-};
+} __attribute__((__aligned__(8)));
 
 /* Unwinding functions */
 _Unwind_Reason_Code _Unwind_RaiseException(struct _Unwind_Exception *ucbp);

--- a/src/unwind-itanium.h
+++ b/src/unwind-itanium.h
@@ -78,9 +78,12 @@ struct _Unwind_Exception
   {
     uint64_t exception_class;
     _Unwind_Exception_Cleanup_Fn exception_cleanup;
-    unsigned long private_1;
-    unsigned long private_2;
-  } ;
+    uintptr_t private_1;
+    uintptr_t private_2;
+#if __SIZEOF_POINTER__ == 4
+    uint32_t reserved[3];
+#endif
+  } __attribute__((__aligned__));
 
 extern _Unwind_Reason_Code _Unwind_RaiseException (struct _Unwind_Exception *);
 extern _Unwind_Reason_Code _Unwind_ForcedUnwind (struct _Unwind_Exception *,


### PR DESCRIPTION
Updated _Unwind_Exception structs to match latest revisions from libunwind:

- ARM version is using `__attribute__((__aligned__(8)))`:  
https://github.com/llvm/llvm-project/blob/master/libunwind/include/unwind.h#L107

- Itanium version is using `__attribute__((__aligned__))`, `uintptr_t` for private fields, and an added `reserved` field to be explicit about alignment:
https://github.com/llvm/llvm-project/blob/master/libunwind/include/unwind.h#L123-L143
